### PR TITLE
Use absolute paths for executables.

### DIFF
--- a/scripts/nvhda-resume.service
+++ b/scripts/nvhda-resume.service
@@ -4,7 +4,7 @@ After=suspend.target
 
 [Service]
 Type=oneshot
-ExecStart=echo "ON" >/proc/acpi/nvhda
+ExecStart=/bin/echo "ON" >/proc/acpi/nvhda
 
 [Install]
 WantedBy=suspend.target

--- a/scripts/nvhda-suspend.service
+++ b/scripts/nvhda-suspend.service
@@ -4,7 +4,7 @@ Before=sleep.target
 
 [Service]
 Type=oneshot
-ExecStart=echo "OFF" >/proc/acpi/nvhda
+ExecStart=/bin/echo "OFF" >/proc/acpi/nvhda
 
 [Install]
 WantedBy=sleep.target


### PR DESCRIPTION
Otherwise systemd will abort, refusing to run the nvhda-resume and
nvhda-suspend services.