### PR TITLE
nvhda startup script (for systemd)

### DIFF
--- a/scripts/nvhda-start.service
+++ b/scripts/nvhda-start.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=nvhda start
+Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.service getty@tty5.service getty@tty6.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "/bin/echo ON >/proc/acpi/nvhda"
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Nice! I was trying to get it working, and after some work on enabling the hdmi audio controller echoing 1 around /sys/, I've discovered your module. And it works like a charm! Every time is called, without problems (I get my scripts working twice instead, so..). Tried https://devtalk.nvidia.com/default/topic/1024022/linux/gtx-1060-no-audio-over-hdmi-only-hda-intel-detected-azalia/ before, to try writing working scripts.

Anyway, I've written and tried this startup systemd script. It is working without problems on Ubuntu 18.10, so it should be wokring in every systemd based distribution.

Just enabling it with a systemctl enable nvhda-start.service , after copied it under /etc/systemd/system/ (could be /lib/systemd/system/ ).

I'm "sad" only because the audio controller is working (at least as far as I've tried) only with the nvidia proprietary driver, even if is seen by Alsa with nouveau loaded too (with nouveau, pavucontrol sees the card but unplugged, instead plugged with the nvidia driver)

Hope it helps!
