### PR TITLE
add modprobe to nvhda-start.service ; adjust README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Since its logic is copied from the bbswitch module, it works like that.
 
 Check dmesg for messages.
 
-### Enable on bootup (on a debian-like system)
+### Enable on bootup (using systemd)
     # cd scripts
     # sudo sh -c "for service in *.service ; do cp \$service /lib/systemd/system ; systemctl enable \$service ; done"
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Since its logic is copied from the bbswitch module, it works like that.
 
 Check dmesg for messages.
 
+### Enable on bootup (on a debian-like system)
+    # cd scripts
+    # sudo sh -c "for service in *.service ; do cp \$service /lib/systemd/system ; systemctl enable \$service ; done"
+
 How it works
 ------------
 See:

--- a/scripts/nvhda-start.service
+++ b/scripts/nvhda-start.service
@@ -4,7 +4,7 @@ Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.servi
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "modprobe nvhda && /bin/echo ON >/proc/acpi/nvhda"
+ExecStart=/bin/sh -c "/sbin/modprobe nvhda && /bin/echo ON >/proc/acpi/nvhda"
 
 [Install]
 WantedBy=default.target

--- a/scripts/nvhda-start.service
+++ b/scripts/nvhda-start.service
@@ -4,7 +4,7 @@ Before=getty@tty1.service getty@tty2.service getty@tty3.service getty@tty4.servi
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c "/bin/echo ON >/proc/acpi/nvhda"
+ExecStart=/bin/sh -c "modprobe nvhda && /bin/echo ON >/proc/acpi/nvhda"
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
I needed to add the `modprobe` line lest the `echo` complain of missing `/proc/acpi/nvhda`.